### PR TITLE
DeregisterAll removes all previously registered health checkers

### DIFF
--- a/health.go
+++ b/health.go
@@ -99,6 +99,14 @@ var (
 	logSubsystem = slog.String("subsystem", "health")
 )
 
+// DeregisterAll removes all previously registered health checkers.
+func DeregisterAll() {
+	checkersMu.Lock()
+	defer checkersMu.Unlock()
+
+	checkers = nil
+}
+
 // Checker can be implemented by anything whose health can be checked.
 type Checker interface {
 	CheckHealth(ctx context.Context) (checks []Check)

--- a/server.go
+++ b/server.go
@@ -88,6 +88,7 @@ func HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	resp, err := CheckNow(ctx)
 	if err != nil {
 		errorStatus(err, http.StatusInternalServerError)
+		return
 	}
 
 	if resp.Status == StatusFail {


### PR DESCRIPTION
 DeregisterAll removes all previously registered health checkers

Add missing return in HandleHTTP